### PR TITLE
Convert memory read to async, fix compatibility with some RF clients

### DIFF
--- a/GameMemory.cs
+++ b/GameMemory.cs
@@ -263,8 +263,8 @@ async Task MemoryReadThread(CancellationToken cancellationToken)
                 return null;
             }
 
-            // asynchronous 500ms delay to give time for the window title to populate before we check it
-            await Task.Delay(500);
+            // asynchronous delay to give time for the window title to populate before we check it
+            await Task.Delay(1000);
 
             // retrieve window title and trim spaces
             string windowTitle = game.MainWindowTitle?.Trim();

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿LiveSplit.RedFaction
 =====================
 
-LiveSplit.RedFaction is a [LiveSplit](http://livesplit.org/) component for Red Faction (Pure Faction).
+LiveSplit.RedFaction is a [LiveSplit](http://livesplit.org/) component for Red Faction.
 
 Features
 --------
@@ -12,7 +12,10 @@ Features
 Requirements
 -------
 * LiveSplit 1.6+
-* Red Faction 1.20 (can be DashFaction) or Pure Faction 3.0d
+* One of the following Red Faction client versions:
+	* Official version v1.20 or 1.21
+	* Dash Faction (any version)
+	* Pure Faction 3.0d or 3.0e
 
 Install
 -------


### PR DESCRIPTION
This PR:

- Converts the previous memory read approach to async (with _a lot_ of help on proper syntax and C# best practice from ChatGPT)
- Shifts to a window title check instead of checking the memory size of loaded modules to identify valid RF processes. This approach is futureproof in that it allows use of any Dash versions going forward without further updates to the component being necessary
- Reformats some code to help with readability and adds some additional comments to help anyone interpret the code